### PR TITLE
Use curl to fetch model only if git lfs is not available

### DIFF
--- a/scripts/fw_dw_hf_wo_lfs.sh
+++ b/scripts/fw_dw_hf_wo_lfs.sh
@@ -13,7 +13,7 @@ fi
 url_pfx="https://huggingface.co/guillaumekln"
 function fetch {
     git clone "$hf_url" "$WSCRIBE_MODELS_DIR/$model_name"
-    curl -L "$hf_url/resolve/main/model.bin" -o "$WSCRIBE_MODELS_DIR/$model_name/model.bin"
+    git lfs pull || curl -L "$hf_url/resolve/main/model.bin" -o "$WSCRIBE_MODELS_DIR/$model_name/model.bin"
 }
 
 


### PR DESCRIPTION
I was using the script to simplify the model fetching. But I already had lfs installed. So it automatically fetched it via lfs. And this was getting rewritten with the curl command. This will do curl only if lfs fails.